### PR TITLE
Change properties from private to protected

### DIFF
--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -19,17 +19,17 @@ class Argument
     /**
      * @var Type
      */
-    private $type;
+    protected $type;
 
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string|null
      */
-    private $defaultValue;
+    protected $defaultValue;
 
     /**
      * @param string $type

--- a/src/Memio/Model/Constant.php
+++ b/src/Memio/Model/Constant.php
@@ -19,12 +19,12 @@ class Constant
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string
      */
-    private $value;
+    protected $value;
 
     /**
      * @param string $name

--- a/src/Memio/Model/Contract.php
+++ b/src/Memio/Model/Contract.php
@@ -23,27 +23,27 @@ class Contract implements Structure
     /**
      * @var string
      */
-    private $fullyQualifiedName;
+    protected $fullyQualifiedName;
 
     /**
      * @var StructurePhpdoc
      */
-    private $structurePhpdoc;
+    protected $structurePhpdoc;
 
     /**
      * @var array
      */
-    private $contracts = array();
+    protected $contracts = array();
 
     /**
      * @var array
      */
-    private $constants = array();
+    protected $constants = array();
 
     /**
      * @var array
      */
-    private $methods = array();
+    protected $methods = array();
 
     /**
      * @param string $fullyQualifiedName

--- a/src/Memio/Model/File.php
+++ b/src/Memio/Model/File.php
@@ -21,22 +21,22 @@ class File
     /**
      * @var string
      */
-    private $filename;
+    protected $filename;
 
     /**
      * @var LicensePhpdoc
      */
-    private $licensePhpdoc;
+    protected $licensePhpdoc;
 
     /**
      * @var array
      */
-    private $fullyQualifiedNames = array();
+    protected $fullyQualifiedNames = array();
 
     /**
      * @var Strucutre
      */
-    private $structure;
+    protected $structure;
 
     /**
      * @param string $filename

--- a/src/Memio/Model/FullyQualifiedName.php
+++ b/src/Memio/Model/FullyQualifiedName.php
@@ -19,22 +19,22 @@ class FullyQualifiedName
     /**
      * @var string
      */
-    private $fullyQualifiedName;
+    protected $fullyQualifiedName;
 
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string
      */
-    private $namepace;
+    protected $namepace;
 
     /**
      * @var string
      */
-    private $alias;
+    protected $alias;
 
     /**
      * @param string $fullyQualifiedName

--- a/src/Memio/Model/Method.php
+++ b/src/Memio/Model/Method.php
@@ -21,42 +21,42 @@ class Method
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var MethodPhpdoc
      */
-    private $methodPhpdoc;
+    protected $methodPhpdoc;
 
     /**
      * @var bool
      */
-    private $isAbstract = false;
+    protected $isAbstract = false;
 
     /**
      * @var bool
      */
-    private $isFinal = false;
+    protected $isFinal = false;
 
     /**
      * @var string
      */
-    private $visibility = 'public';
+    protected $visibility = 'public';
 
     /**
      * @var bool
      */
-    private $isStatic = false;
+    protected $isStatic = false;
 
     /**
      * @var array
      */
-    private $arguments = array();
+    protected $arguments = array();
 
     /**
      * @var string
      */
-    private $body = '';
+    protected $body = '';
 
     /**
      * @param string $name

--- a/src/Memio/Model/Object.php
+++ b/src/Memio/Model/Object.php
@@ -23,47 +23,47 @@ class Object implements Structure
     /**
      * @var FullyQualifiedName
      */
-    private $fullyQualifiedName;
+    protected $fullyQualifiedName;
 
     /**
      * @var StructurePhpdoc
      */
-    private $structurePhpdoc;
+    protected $structurePhpdoc;
 
     /**
      * @var bool
      */
-    private $isAbstract = false;
+    protected $isAbstract = false;
 
     /**
      * @var bool
      */
-    private $isFinal = false;
+    protected $isFinal = false;
 
     /**
      * @var Object
      */
-    private $parent;
+    protected $parent;
 
     /**
      * @var array
      */
-    private $contracts = array();
+    protected $contracts = array();
 
     /**
      * @var array
      */
-    private $constants = array();
+    protected $constants = array();
 
     /**
      * @var array
      */
-    private $properties = array();
+    protected $properties = array();
 
     /**
      * @var array
      */
-    private $methods = array();
+    protected $methods = array();
 
     /**
      * @param string $fullyQualifiedName

--- a/src/Memio/Model/Phpdoc/ApiTag.php
+++ b/src/Memio/Model/Phpdoc/ApiTag.php
@@ -19,7 +19,7 @@ class ApiTag
     /**
      * @var string
      */
-    private $since;
+    protected $since;
 
     /**
      * @param string $since

--- a/src/Memio/Model/Phpdoc/DeprecationTag.php
+++ b/src/Memio/Model/Phpdoc/DeprecationTag.php
@@ -19,12 +19,12 @@ class DeprecationTag
     /**
      * @var string
      */
-    private $version;
+    protected $version;
 
     /**
      * @var string
      */
-    private $description;
+    protected $description;
 
     /**
      * @param string $version

--- a/src/Memio/Model/Phpdoc/Description.php
+++ b/src/Memio/Model/Phpdoc/Description.php
@@ -16,7 +16,7 @@ class Description
     /**
      * @var array
      */
-    private $description = array();
+    protected $description = array();
 
     /**
      * @param string $line

--- a/src/Memio/Model/Phpdoc/LicensePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/LicensePhpdoc.php
@@ -19,17 +19,17 @@ class LicensePhpdoc
     /**
      * @var string
      */
-    private $projectName;
+    protected $projectName;
 
     /**
      * @var string
      */
-    private $authorName;
+    protected $authorName;
 
     /**
      * @var string
      */
-    private $authorEmail;
+    protected $authorEmail;
 
     /**
      * @param string $projectName

--- a/src/Memio/Model/Phpdoc/MethodPhpdoc.php
+++ b/src/Memio/Model/Phpdoc/MethodPhpdoc.php
@@ -19,22 +19,22 @@ class MethodPhpdoc
     /**
      * @var ApiTag
      */
-    private $apiTag;
+    protected $apiTag;
 
     /**
      * @var DeprecationTag
      */
-    private $deprecationTag;
+    protected $deprecationTag;
 
     /**
      * @var Description
      */
-    private $description;
+    protected $description;
 
     /**
      * @var array
      */
-    private $parameterTags = array();
+    protected $parameterTags = array();
 
     /**
      * @return MethodPhpdoc

--- a/src/Memio/Model/Phpdoc/ParameterTag.php
+++ b/src/Memio/Model/Phpdoc/ParameterTag.php
@@ -21,17 +21,17 @@ class ParameterTag
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string
      */
-    private $description;
+    protected $description;
 
     /**
      * @param string $type

--- a/src/Memio/Model/Phpdoc/PropertyPhpdoc.php
+++ b/src/Memio/Model/Phpdoc/PropertyPhpdoc.php
@@ -19,7 +19,7 @@ class PropertyPhpdoc
     /**
      * @var VariableTag
      */
-    private $variableTag;
+    protected $variableTag;
 
     /**
      * @return PropertyPhpdoc

--- a/src/Memio/Model/Phpdoc/StructurePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/StructurePhpdoc.php
@@ -19,17 +19,17 @@ class StructurePhpdoc
     /**
      * @var ApiTag
      */
-    private $apiTag;
+    protected $apiTag;
 
     /**
      * @var DeprecationTag
      */
-    private $deprecationTag;
+    protected $deprecationTag;
 
     /**
      * @var Description
      */
-    private $description;
+    protected $description;
 
     /**
      * @return StructurePhpdoc

--- a/src/Memio/Model/Phpdoc/VariableTag.php
+++ b/src/Memio/Model/Phpdoc/VariableTag.php
@@ -18,7 +18,7 @@ class VariableTag
     /**
      * @var Type
      */
-    private $type;
+    protected $type;
 
     /**
      * @param string $type

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -21,27 +21,27 @@ class Property
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var PropertyPhpdoc
      */
-    private $propertyPhpdoc;
+    protected $propertyPhpdoc;
 
     /**
      * @var bool
      */
-    private $isStatic = false;
+    protected $isStatic = false;
 
     /**
      * @var string
      */
-    private $visibility = 'private';
+    protected $visibility = 'private';
 
     /**
      * @var string
      */
-    private $defaultValue;
+    protected $defaultValue;
 
     /**
      * @param string $name

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -21,22 +21,22 @@ class Type
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var FullyQualifiedName
      */
-    private $fullyqualifiedName;
+    protected $fullyqualifiedName;
 
     /**
      * @var bool
      */
-    private $isObject;
+    protected $isObject;
 
     /**
      * @var bool
      */
-    private $hasTypeHint;
+    protected $hasTypeHint;
 
     /**
      * @param string $name


### PR DESCRIPTION
I'm looking to modify the Memio model component to support Zephir syntax. This pull request changes `private` properties to `protected` to allow for extension of the model behavior. Any objections?
