### PR TITLE
Add support for variadic arguments.

### DIFF
--- a/spec/Memio/Model/ArgumentSpec.php
+++ b/spec/Memio/Model/ArgumentSpec.php
@@ -40,4 +40,15 @@ class ArgumentSpec extends ObjectBehavior
         $this->removeDefaultValue();
         $this->getDefaultValue()->shouldBe(null);
     }
+
+    function it_can_be_variadic()
+    {
+        $this->isVariadic()->shouldBe(false);
+
+        $this->makeVariadic();
+        $this->isVariadic()->shouldBe(true);
+
+        $this->removeVariadic();
+        $this->isVariadic()->shouldBe(false);
+    }
 }

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -19,6 +19,7 @@ class Argument
     private $type;
     private $name;
     private $defaultValue;
+    private $isVariadic = false;
 
     /**
      * @api
@@ -68,6 +69,34 @@ class Argument
     public function removeDefaultValue() : self
     {
         $this->defaultValue = null;
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function isVariadic(): bool
+    {
+        return $this->isVariadic;
+    }
+
+    /**
+     * @api
+     */
+    public function makeVariadic() : self
+    {
+        $this->isVariadic = true;
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function removeVariadic() : self
+    {
+        $this->isVariadic = false;
 
         return $this;
     }


### PR DESCRIPTION
A variadic argument will be rendered with three dots prefixed. See
http://php.net/manual/en/functions.arguments.php#functions.variable-arg-list

I have taken the naming conventions from Objekt::isAbstract, is this right way to name the properties and methods?

The file argument.twig will be changed as follows:

`
{% if argument.variadic %}...{% endif %}${{ argument.name -}}
`