### PR TITLE
v4.0.0: PHP 8.0

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -35,8 +35,8 @@ $finder = (new PhpCsFixer\Finder())
 return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
+        '@PHP71Migration' => true,
+        '@PHP71Migration:risky' => true,
 
         // [Symfony] defaults to `camelCase`, we set it to `snake_case` (phpspec style)
         'php_unit_method_casing' => ['case' => 'snake_case'],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -35,11 +35,14 @@ $finder = (new PhpCsFixer\Finder())
 return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
-        '@PHP74Migration' => true,
-        '@PHP74Migration:risky' => true,
+        '@PHP80Migration' => true,
+        '@PHP80Migration:risky' => true,
 
         // [Symfony] defaults to `camelCase`, we set it to `snake_case` (phpspec style)
         'php_unit_method_casing' => ['case' => 'snake_case'],
+
+        // [Symfony] defaults to `['arrays']`, we add `arguments` and `parameters` (PHP 8.0)
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
 
         // [Symfony] defaults to `true`, we set it to `false` for phpspec
         'visibility_required' => false,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -35,6 +35,8 @@ $finder = (new PhpCsFixer\Finder())
 return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
+        '@PHP70Migration' => true,
+        '@PHP70Migration:risky' => true,
 
         // [Symfony] defaults to `camelCase`, we set it to `snake_case` (phpspec style)
         'php_unit_method_casing' => ['case' => 'snake_case'],
@@ -42,6 +44,7 @@ return (new PhpCsFixer\Config())
         // [Symfony] defaults to `true`, we set it to `false` for phpspec
         'visibility_required' => false,
     ])
+    ->setRiskyAllowed(true)
     ->setUsingCache(true)
     ->setFinder($finder)
 ;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -35,7 +35,7 @@ $finder = (new PhpCsFixer\Finder())
 return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
-        '@PHP71Migration' => true,
+        '@PHP73Migration' => true,
         '@PHP71Migration:risky' => true,
 
         // [Symfony] defaults to `camelCase`, we set it to `snake_case` (phpspec style)

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -35,8 +35,8 @@ $finder = (new PhpCsFixer\Finder())
 return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
-        '@PHP73Migration' => true,
-        '@PHP71Migration:risky' => true,
+        '@PHP74Migration' => true,
+        '@PHP74Migration:risky' => true,
 
         // [Symfony] defaults to `camelCase`, we set it to `snake_case` (phpspec style)
         'php_unit_method_casing' => ['case' => 'snake_case'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 4.0.0: PHP 7.3 requirement
+
+Dropped support for PHP <7.3
+
 ## 3.0.2: Dockerised dev environment
 
 * setup Github Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ New features:
 
 * setup Github Actions
 * changed tooling from scripts to Makefile
-* installed phpstan as a dev depdendency
-* installed swiss-knife as a dev depdendency
-* installed rector as a dev depdendency
+* installed phpstan as a dev dependency
+* installed swiss-knife as a dev dependency
+* installed rector as a dev dependency
 * upgraded PHP CS fixer to v2.19.3
 * dockerized for local development
 
@@ -55,7 +55,7 @@ Normalization from float to double, thanks to @ItsKelsBoys
 
 Added support for PHP 7.2, thanks to @roukmoute
 
-BC break: Object has be renamed to Objekt, has it is a reserved keyword.
+BC break: Object has been renamed to Objekt, has it is a reserved keyword.
 
 ## 2.0.0: PHP 7 and Return type hints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dropped support for PHP <8.0
 
 New features:
 
+* added `Attribute` model (PHP 8.0 attributes)
+* added attributes support to `Objekt`, `Contract`, `Method`, `Property`, `Argument` and `Constant`
+* added union type support in `Type` (e.g. `string|int`, `DateTime|null`)
+* added `mixed` type hint support in `Type`
 * added support for class property types
 * added support for nullable typehints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Dropped support for PHP <7.4
 New features:
 
 * added support for class property types
+* added support for nullable typehints
 
 ## 3.0.2: Dockerised dev environment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 * added union type support in `Type` (e.g. `string|int`, `DateTime|null`)
 * added `mixed` type hint support in `Type`
 * added support for class property types
+* added constructor property promotion support (visibility on `Argument`)
 * added support for nullable typehints
 
 ## 3.0.2: Dockerised dev environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## 4.0.0: PHP 7.3 requirement
+## 4.0.0: PHP 7.4 requirement
 
-Dropped support for PHP <7.3
+Dropped support for PHP <7.4
 
 ## 3.0.2: Dockerised dev environment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Dropped support for PHP <7.4
 
+New features:
+
+* added support for class property types
+
 ## 3.0.2: Dockerised dev environment
 
 * setup Github Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## 4.0.0: PHP 7.4 requirement
+## 4.0.0: PHP 8.0 requirement
 
-Dropped support for PHP <7.4
+Dropped support for PHP <8.0
 
 New features:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ make lib-init
 
 ## Standard code
 
-Use [PHP CS fixer](http://cs.sensiolabs.org/) to make your code compliant with
+Use [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) to make your code compliant with
 Memio's coding standards:
 
 ```console
@@ -87,7 +87,7 @@ To keep your fork up-to-date, you should track the upstream (original) one
 using the following command:
 
 ```console
-$ git remote add upstream https://github.com/memio/model.git
+git remote add upstream https://github.com/memio/model.git
 ```
 
 Then get the upstream changes:
@@ -103,7 +103,7 @@ git rebase main
 Finally, publish your changes:
 
 ```console
-$ git push -f origin <your-branch>
+git push -f origin <your-branch>
 ```
 
 Your pull request will be automatically updated.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ method arguments and even PHPdoc) by constructing "Model" objects.
 
 Install it using [Composer](https://getcomposer.org/download):
 
-    composer require memio/model:^3.0
+    composer require memio/model:^4.0
 
 ## Example
 
@@ -113,4 +113,3 @@ And finally some meta documentation:
 * extract `Import` (use statement) from `FullyQualifiedName`
 * get rid of `FullyQualifiedName`
 * support more PHPdoc stuff
-* support annotations

--- a/README.md
+++ b/README.md
@@ -10,17 +10,21 @@ method arguments and even PHPdoc) by constructing "Model" objects.
 
 Install it using [Composer](https://getcomposer.org/download):
 
-    composer require memio/model:^4.0
+```console
+composer require memio/model:^4.0
+```
 
 ## Example
 
-Let's say we want to describe the following method:
+Let's say we want to describe the following constructor:
 
 ```php
-    /**
-     * @api
-     */
-    public function doSomething(ValueObject $valueObject, int $type = self::TYPE_ONE, bool $option = true);
+    public function __construct(
+        private ValueObject $valueObject,
+        private string|int $type = self::TYPE_ONE,
+        private ?bool $option = true,
+    ) {
+    }
 ```
 
 In order to do so, we'd need to write the following:
@@ -32,56 +36,53 @@ require __DIR__.'/vendor/autoload.php';
 
 use Memio\Model\Argument;
 use Memio\Model\Method;
-use Memio\Model\Phpdoc\ApiTag;
-use Memio\Model\Phpdoc\MethodPhpdoc;
-use Memio\Model\Phpdoc\ParameterTag;
 
-$method = (new Method('doSomething'))
-    ->setPhpdoc((new MethodPhpdoc())
-        ->addParameterTag(new ParameterTag('Vendor\Project\ValueObject', 'valueObject'))
-        ->addParameterTag(new ParameterTag('int', 'type'))
-        ->addParameterTag(new ParameterTag('bool', 'option'))
-
-        ->addApiTag(new ApiTag())
+$method = (new Method('__construct'))
+    ->addArgument((new Argument('Vendor\Project\ValueObject', 'valueObject'))
+        ->makePrivate()
     )
-    ->addArgument(new Argument('Vendor\Project\ValueObject', 'valueObject'))
-    ->addArgument((new Argument('int', 'type'))
+    ->addArgument((new Argument('string|int', 'type'))
+        ->makePrivate()
         ->setDefaultValue('self::TYPE_ONE')
     )
-    ->addArgument((new Argument('bool', 'option'))
+    ->addArgument((new Argument('?bool', 'option'))
+        ->makePrivate()
         ->setDefaultValue('true')
     )
 ;
 ```
 
+This example showcases constructor property promotion, union types and nullable types.
+
 Usually models aren't described manually like this, they would be built dynamically:
 
 ```php
-// Let's say we've received the following two parameters:
-$methodName = 'doSomething';
-$arguments = [new \Vendor\Project\ValueObject(), ValueObject::TYPE_ONE, true];
+// Let's say we've received the following parameters:
+$parameters = [
+    ['type' => 'Vendor\Project\ValueObject', 'name' => 'valueObject'],
+    ['type' => 'string|int', 'name' => 'type', 'default' => 'self::TYPE_ONE'],
+    ['type' => '?bool', 'name' => 'option', 'default' => 'true'],
+];
 
-$method = new Method($methodName);
-$phpdoc = (new MethodPhpdoc())->setApiTag(new ApiTag());
-$index = 1;
-foreach ($arguments as $rawArgument) {
-    $type = is_object($rawArgument) ? get_class($argument) : gettype($rawArgument);
-    $name = 'argument'.$index++;
-    $argument = new Argument($type, $name);
-
+$method = new Method('__construct');
+foreach ($parameters as $parameter) {
+    $argument = (new Argument($parameter['type'], $parameter['name']))
+        ->makePrivate()
+    ;
+    if (isset($parameter['default'])) {
+        $argument->setDefaultValue($parameter['default']);
+    }
     $method->addArgument($argument);
-    $phpdoc->addParameterTag(new ParameterTag($type, $name));
 }
-$method->setPhpdoc($phpdoc);
 ```
 
 We can build dynamically the models using a configuration file, user input, existing
-source code... Possibilities are endless!
+source code, etc. Possibilities are endless!
 
-Once built these models can be further tweaked, and converted to another format:
-an array, source code, etc... Again, the possibilities are endless!
+Once built, these models can be further tweaked and converted to another format:
+an array, source code, etc.
 
-Have a look at [the main respository](http://github.com/memio/memio) to discover the full power of Medio.
+Have a look at [the main repository](http://github.com/memio/memio) to discover the full power of Memio.
 
 ## Want to know more?
 
@@ -98,7 +99,7 @@ make phpspec arg='--format pretty'   # Run the specifications
 You can see the current and past versions using one of the following:
 
 * the `git tag` command
-* the [releases page on Github](https://github.com/memio/memio/releases)
+* the [releases page on Github](https://github.com/memio/model/releases)
 * the file listing the [changes between versions](CHANGELOG.md)
 
 And finally some meta documentation:

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         "Memio\\Model\\": "src/Memio/Model"
     }},
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19.3",
-        "phpspec/phpspec": "^6.1 || ^7.0",
+        "phpspec/phpspec": "^7.0",
         "phpstan/phpstan": "1.12.32",
         "rector/rector": "^1.2.10",
         "rector/swiss-knife": "^2.3"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "Memio\\Model\\": "src/Memio/Model"
     }},
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "Memio\\Model\\": "src/Memio/Model"
     }},
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19.3",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,6 @@ includes:
 
 parameters:
   level: 0
-  phpVersion: 70400
+  phpVersion: 80000
   paths:
     - src/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,6 @@ includes:
 
 parameters:
   level: 0
-  phpVersion: 70200
+  phpVersion: 70300
   paths:
     - src/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,6 @@ includes:
 
 parameters:
   level: 0
-  phpVersion: 70300
+  phpVersion: 70400
   paths:
     - src/

--- a/rector.php
+++ b/rector.php
@@ -23,7 +23,7 @@ return RectorConfig::configure()
     ])
     ->withSets([
         // —— PHP ——————————————————————————————————————————————————————————————
-        SetList::PHP_72,
+        SetList::PHP_73,
     ])
     ->withRules([
     ]);

--- a/rector.php
+++ b/rector.php
@@ -23,7 +23,7 @@ return RectorConfig::configure()
     ])
     ->withSets([
         // —— PHP ——————————————————————————————————————————————————————————————
-        SetList::PHP_73,
+        SetList::PHP_74,
     ])
     ->withRules([
     ]);

--- a/rector.php
+++ b/rector.php
@@ -9,7 +9,7 @@ use Rector\Set\ValueObject\SetList;
 return RectorConfig::configure()
     ->withCache(
         '/tmp/rector',
-        FileCacheStorage::class
+        FileCacheStorage::class,
     )
     ->withPaths([
         __DIR__,
@@ -23,7 +23,7 @@ return RectorConfig::configure()
     ])
     ->withSets([
         // —— PHP ——————————————————————————————————————————————————————————————
-        SetList::PHP_74,
+        SetList::PHP_80,
     ])
     ->withRules([
     ]);

--- a/spec/Memio/Model/ArgumentSpec.php
+++ b/spec/Memio/Model/ArgumentSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Memio\Model;
 
+use Memio\Model\Attribute;
 use PhpSpec\ObjectBehavior;
 
 class ArgumentSpec extends ObjectBehavior
@@ -52,5 +53,12 @@ class ArgumentSpec extends ObjectBehavior
 
         $this->removeVariadic();
         $this->isVariadic()->shouldBe(false);
+    }
+
+    function it_can_have_attributes(Attribute $attribute): void
+    {
+        $this->attributes->shouldBe([]);
+        $this->addAttribute($attribute);
+        $this->attributes->shouldBe([$attribute]);
     }
 }

--- a/spec/Memio/Model/ArgumentSpec.php
+++ b/spec/Memio/Model/ArgumentSpec.php
@@ -60,5 +60,7 @@ class ArgumentSpec extends ObjectBehavior
         $this->attributes->shouldBe([]);
         $this->addAttribute($attribute);
         $this->attributes->shouldBe([$attribute]);
+        $this->removeAttributes();
+        $this->attributes->shouldBe([]);
     }
 }

--- a/spec/Memio/Model/ArgumentSpec.php
+++ b/spec/Memio/Model/ArgumentSpec.php
@@ -17,22 +17,22 @@ use PhpSpec\ObjectBehavior;
 
 class ArgumentSpec extends ObjectBehavior
 {
-    function let()
+    function let(): void
     {
         $this->beConstructedWith('array', 'lines');
     }
 
-    function it_has_a_type()
+    function it_has_a_type(): void
     {
         $this->type->name->shouldBe('array');
     }
 
-    function it_has_a_name()
+    function it_has_a_name(): void
     {
         $this->name->shouldBe('lines');
     }
 
-    function it_can_have_default_value()
+    function it_can_have_default_value(): void
     {
         $this->defaultValue->shouldBe(null);
 
@@ -43,7 +43,7 @@ class ArgumentSpec extends ObjectBehavior
         $this->defaultValue->shouldBe(null);
     }
 
-    function it_can_be_variadic()
+    function it_can_be_variadic(): void
     {
         $this->isVariadic()->shouldBe(false);
 

--- a/spec/Memio/Model/ArgumentSpec.php
+++ b/spec/Memio/Model/ArgumentSpec.php
@@ -63,4 +63,21 @@ class ArgumentSpec extends ObjectBehavior
         $this->removeAttributes();
         $this->attributes->shouldBe([]);
     }
+
+    function it_can_have_visibility(): void
+    {
+        $this->visibility->shouldBe('');
+
+        $this->makePublic();
+        $this->visibility->shouldBe('public');
+
+        $this->makeProtected();
+        $this->visibility->shouldBe('protected');
+
+        $this->makePrivate();
+        $this->visibility->shouldBe('private');
+
+        $this->removeVisibility();
+        $this->visibility->shouldBe('');
+    }
 }

--- a/spec/Memio/Model/ArgumentSpec.php
+++ b/spec/Memio/Model/ArgumentSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/AttributeSpec.php
+++ b/spec/Memio/Model/AttributeSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the memio/model package.
+ *
+ * (c) Loïc Faugeron <faugeron.loic@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Memio\Model;
+
+use PhpSpec\ObjectBehavior;
+
+class AttributeSpec extends ObjectBehavior
+{
+    const NAME = 'Route';
+
+    function let(): void
+    {
+        $this->beConstructedWith(self::NAME);
+    }
+
+    function it_has_a_name(): void
+    {
+        $this->name->shouldBe(self::NAME);
+    }
+
+    function it_can_have_arguments(): void
+    {
+        $this->arguments->shouldBe(null);
+
+        $this->setArguments("'/api'");
+        $this->arguments->shouldBe("'/api'");
+    }
+}

--- a/spec/Memio/Model/ConstantSpec.php
+++ b/spec/Memio/Model/ConstantSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Memio\Model;
 
+use Memio\Model\Attribute;
 use PhpSpec\ObjectBehavior;
 
 class ConstantSpec extends ObjectBehavior
@@ -33,5 +34,12 @@ class ConstantSpec extends ObjectBehavior
     function it_has_a_value(): void
     {
         $this->value->shouldBe(self::VALUE);
+    }
+
+    function it_can_have_attributes(Attribute $attribute): void
+    {
+        $this->attributes->shouldBe([]);
+        $this->addAttribute($attribute);
+        $this->attributes->shouldBe([$attribute]);
     }
 }

--- a/spec/Memio/Model/ConstantSpec.php
+++ b/spec/Memio/Model/ConstantSpec.php
@@ -41,5 +41,7 @@ class ConstantSpec extends ObjectBehavior
         $this->attributes->shouldBe([]);
         $this->addAttribute($attribute);
         $this->attributes->shouldBe([$attribute]);
+        $this->removeAttributes();
+        $this->attributes->shouldBe([]);
     }
 }

--- a/spec/Memio/Model/ConstantSpec.php
+++ b/spec/Memio/Model/ConstantSpec.php
@@ -20,17 +20,17 @@ class ConstantSpec extends ObjectBehavior
     const NAME = 'MY_CONSTANT';
     const VALUE = "'my string value'";
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::NAME, self::VALUE);
     }
 
-    function it_has_a_name()
+    function it_has_a_name(): void
     {
         $this->name->shouldBe(self::NAME);
     }
 
-    function it_has_a_value()
+    function it_has_a_value(): void
     {
         $this->value->shouldBe(self::VALUE);
     }

--- a/spec/Memio/Model/ConstantSpec.php
+++ b/spec/Memio/Model/ConstantSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/ContractSpec.php
+++ b/spec/Memio/Model/ContractSpec.php
@@ -84,5 +84,7 @@ class ContractSpec extends ObjectBehavior
         $this->attributes->shouldBe([]);
         $this->addAttribute($attribute);
         $this->attributes->shouldBe([$attribute]);
+        $this->removeAttributes();
+        $this->attributes->shouldBe([]);
     }
 }

--- a/spec/Memio/Model/ContractSpec.php
+++ b/spec/Memio/Model/ContractSpec.php
@@ -25,53 +25,53 @@ class ContractSpec extends ObjectBehavior
     const NAME = 'MyInterface';
     const NAMESPACE_ = 'Vendor\Project';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::FULLY_QUALIFIED_NAME);
     }
 
-    function it_is_a_structure()
+    function it_is_a_structure(): void
     {
         $this->shouldImplement('Memio\Model\Structure');
     }
 
-    function it_has_a_fully_qualified_name()
+    function it_has_a_fully_qualified_name(): void
     {
         $this->fullyQualifiedName->fullyQualifiedName->shouldBe(self::FULLY_QUALIFIED_NAME);
     }
 
-    function it_has_a_name()
+    function it_has_a_name(): void
     {
         $this->getName()->shouldBe(self::NAME);
     }
 
-    function it_has_a_namespace()
+    function it_has_a_namespace(): void
     {
         $this->getNamespace()->shouldBe(self::NAMESPACE_);
     }
 
-    function it_can_have_phpdoc(StructurePhpdoc $phpdoc)
+    function it_can_have_phpdoc(StructurePhpdoc $phpdoc): void
     {
         $this->structurePhpdoc->shouldBe(null);
         $this->setPhpdoc($phpdoc);
         $this->structurePhpdoc->shouldBe($phpdoc);
     }
 
-    function it_can_extend_contracts(Contract $contract)
+    function it_can_extend_contracts(Contract $contract): void
     {
         $this->contracts->shouldBe([]);
         $this->extend($contract);
         $this->contracts->shouldBe([$contract]);
     }
 
-    function it_can_have_constants(Constant $constant)
+    function it_can_have_constants(Constant $constant): void
     {
         $this->constants->shouldBe([]);
         $this->addConstant($constant);
         $this->constants->shouldBe([$constant]);
     }
 
-    function it_can_have_methods(Method $method)
+    function it_can_have_methods(Method $method): void
     {
         $this->methods->shouldBe([]);
         $this->addMethod($method);

--- a/spec/Memio/Model/ContractSpec.php
+++ b/spec/Memio/Model/ContractSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/ContractSpec.php
+++ b/spec/Memio/Model/ContractSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Memio\Model;
 
+use Memio\Model\Attribute;
 use Memio\Model\Constant;
 use Memio\Model\Contract;
 use Memio\Model\Method;
@@ -76,5 +77,12 @@ class ContractSpec extends ObjectBehavior
         $this->methods->shouldBe([]);
         $this->addMethod($method);
         $this->methods->shouldBe([$method]);
+    }
+
+    function it_can_have_attributes(Attribute $attribute): void
+    {
+        $this->attributes->shouldBe([]);
+        $this->addAttribute($attribute);
+        $this->attributes->shouldBe([$attribute]);
     }
 }

--- a/spec/Memio/Model/FileSpec.php
+++ b/spec/Memio/Model/FileSpec.php
@@ -24,17 +24,17 @@ class FileSpec extends ObjectBehavior
     const NAMESPACE_ = 'Vendor\Project';
     const CLASSNAME = 'MyClass';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::FILENAME);
     }
 
-    function it_has_a_filename()
+    function it_has_a_filename(): void
     {
         $this->filename->shouldBe(self::FILENAME);
     }
 
-    function it_can_have_license_phpdoc(LicensePhpdoc $licensePhpdoc)
+    function it_can_have_license_phpdoc(LicensePhpdoc $licensePhpdoc): void
     {
         $this->licensePhpdoc->shouldBe(null);
 
@@ -45,7 +45,7 @@ class FileSpec extends ObjectBehavior
         $this->licensePhpdoc->shouldBe(null);
     }
 
-    function it_has_a_namespace(Structure $structure)
+    function it_has_a_namespace(Structure $structure): void
     {
         $structure->getNamespace()->willReturn(self::NAMESPACE_);
 
@@ -54,14 +54,14 @@ class FileSpec extends ObjectBehavior
         $this->structure->getNamespace()->shouldBe(self::NAMESPACE_);
     }
 
-    function it_can_have_fully_qualified_names(FullyQualifiedName $fullyQualifiedName)
+    function it_can_have_fully_qualified_names(FullyQualifiedName $fullyQualifiedName): void
     {
         $this->fullyQualifiedNames->shouldBe([]);
         $this->addFullyQualifiedName($fullyQualifiedName);
         $this->fullyQualifiedNames->shouldBe([$fullyQualifiedName]);
     }
 
-    function it_has_a_structure(Structure $structure)
+    function it_has_a_structure(Structure $structure): void
     {
         $this->setStructure($structure);
 

--- a/spec/Memio/Model/FileSpec.php
+++ b/spec/Memio/Model/FileSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/FullyQualifiedNameSpec.php
+++ b/spec/Memio/Model/FullyQualifiedNameSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/FullyQualifiedNameSpec.php
+++ b/spec/Memio/Model/FullyQualifiedNameSpec.php
@@ -17,27 +17,27 @@ use PhpSpec\ObjectBehavior;
 
 class FullyQualifiedNameSpec extends ObjectBehavior
 {
-    function let()
+    function let(): void
     {
         $this->beConstructedWith('Vendor\Project\MyClass');
     }
 
-    function it_has_fully_qualified_classname()
+    function it_has_fully_qualified_classname(): void
     {
         $this->fullyQualifiedName->shouldBe('Vendor\Project\MyClass');
     }
 
-    function it_has_name()
+    function it_has_name(): void
     {
         $this->getName()->shouldBe('MyClass');
     }
 
-    function it_has_namespace()
+    function it_has_namespace(): void
     {
         $this->namespace->shouldBe('Vendor\Project');
     }
 
-    function it_can_have_an_alias()
+    function it_can_have_an_alias(): void
     {
         $this->hasAlias()->shouldBe(false);
         $this->getName()->shouldBe('MyClass');
@@ -51,7 +51,7 @@ class FullyQualifiedNameSpec extends ObjectBehavior
         $this->getName()->shouldBe('MyClass');
     }
 
-    function it_normalizes_float_name()
+    function it_normalizes_float_name(): void
     {
         $this->beConstructedWith('float');
 

--- a/spec/Memio/Model/MethodSpec.php
+++ b/spec/Memio/Model/MethodSpec.php
@@ -105,8 +105,8 @@ class MethodSpec extends ObjectBehavior
     function it_can_have_a_body(): void
     {
         $body = <<<'EOT'
-        $length = strlen('Nobody expects the spanish inquisition');
-EOT;
+                    $length = strlen('Nobody expects the spanish inquisition');
+            EOT;
         $this->setBody($body);
         $this->body->shouldBe($body);
     }

--- a/spec/Memio/Model/MethodSpec.php
+++ b/spec/Memio/Model/MethodSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Memio\Model;
 
 use Memio\Model\Argument;
+use Memio\Model\Attribute;
 use Memio\Model\Phpdoc\MethodPhpdoc;
 use PhpSpec\ObjectBehavior;
 
@@ -109,5 +110,12 @@ class MethodSpec extends ObjectBehavior
             EOT;
         $this->setBody($body);
         $this->body->shouldBe($body);
+    }
+
+    function it_can_have_attributes(Attribute $attribute): void
+    {
+        $this->attributes->shouldBe([]);
+        $this->addAttribute($attribute);
+        $this->attributes->shouldBe([$attribute]);
     }
 }

--- a/spec/Memio/Model/MethodSpec.php
+++ b/spec/Memio/Model/MethodSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/MethodSpec.php
+++ b/spec/Memio/Model/MethodSpec.php
@@ -117,5 +117,7 @@ class MethodSpec extends ObjectBehavior
         $this->attributes->shouldBe([]);
         $this->addAttribute($attribute);
         $this->attributes->shouldBe([$attribute]);
+        $this->removeAttributes();
+        $this->attributes->shouldBe([]);
     }
 }

--- a/spec/Memio/Model/MethodSpec.php
+++ b/spec/Memio/Model/MethodSpec.php
@@ -21,24 +21,24 @@ class MethodSpec extends ObjectBehavior
 {
     const NAME = '__construct';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::NAME);
     }
 
-    function it_has_a_name()
+    function it_has_a_name(): void
     {
         $this->name->shouldBe(self::NAME);
     }
 
-    function it_can_have_phpdoc(MethodPhpdoc $phpdoc)
+    function it_can_have_phpdoc(MethodPhpdoc $phpdoc): void
     {
         $this->methodPhpdoc->shouldBe(null);
         $this->setPhpdoc($phpdoc);
         $this->methodPhpdoc->shouldBe($phpdoc);
     }
 
-    function it_can_be_abstract()
+    function it_can_be_abstract(): void
     {
         $this->isAbstract->shouldBe(false);
 
@@ -49,7 +49,7 @@ class MethodSpec extends ObjectBehavior
         $this->isAbstract->shouldBe(false);
     }
 
-    function it_can_be_final()
+    function it_can_be_final(): void
     {
         $this->isFinal->shouldBe(false);
 
@@ -60,7 +60,7 @@ class MethodSpec extends ObjectBehavior
         $this->isFinal->shouldBe(false);
     }
 
-    function it_can_have_visibility()
+    function it_can_have_visibility(): void
     {
         $this->visibility->shouldBe('public');
 
@@ -77,7 +77,7 @@ class MethodSpec extends ObjectBehavior
         $this->visibility->shouldBe('public');
     }
 
-    function it_can_have_staticness()
+    function it_can_have_staticness(): void
     {
         $this->isStatic->shouldBe(false);
 
@@ -88,21 +88,21 @@ class MethodSpec extends ObjectBehavior
         $this->isStatic->shouldBe(false);
     }
 
-    function it_can_have_arguments(Argument $argument)
+    function it_can_have_arguments(Argument $argument): void
     {
         $this->arguments->shouldBe([]);
         $this->addArgument($argument);
         $this->arguments->shouldBe([$argument]);
     }
 
-    function it_can_have_a_return_type()
+    function it_can_have_a_return_type(): void
     {
         $this->returnType->shouldBe(null);
         $this->setReturnType('array');
         $this->returnType->shouldBe('array');
     }
 
-    function it_can_have_a_body()
+    function it_can_have_a_body(): void
     {
         $body = <<<'EOT'
         $length = strlen('Nobody expects the spanish inquisition');

--- a/spec/Memio/Model/ObjektSpec.php
+++ b/spec/Memio/Model/ObjektSpec.php
@@ -27,39 +27,39 @@ class ObjektSpec extends ObjectBehavior
     const NAME = 'MyClass';
     const NAMESPACE_ = 'Vendor\Project';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::FULLY_QUALIFIED_NAME);
     }
 
-    function it_is_a_structure()
+    function it_is_a_structure(): void
     {
         $this->shouldImplement('Memio\Model\Structure');
     }
 
-    function it_has_a_fully_qualified_name()
+    function it_has_a_fully_qualified_name(): void
     {
         $this->getFullyQualifiedName()->fullyQualifiedName->shouldBe(self::FULLY_QUALIFIED_NAME);
     }
 
-    function it_has_a_name()
+    function it_has_a_name(): void
     {
         $this->getName()->shouldBe(self::NAME);
     }
 
-    function it_has_a_namespace()
+    function it_has_a_namespace(): void
     {
         $this->getNamespace()->shouldBe(self::NAMESPACE_);
     }
 
-    function it_can_have_phpdoc(StructurePhpdoc $phpdoc)
+    function it_can_have_phpdoc(StructurePhpdoc $phpdoc): void
     {
         $this->structurePhpdoc->shouldBe(null);
         $this->setPhpdoc($phpdoc);
         $this->structurePhpdoc->shouldBe($phpdoc);
     }
 
-    function it_can_be_abstract()
+    function it_can_be_abstract(): void
     {
         $this->isAbstract->shouldBe(false);
         $this->makeAbstract();
@@ -68,7 +68,7 @@ class ObjektSpec extends ObjectBehavior
         $this->isAbstract->shouldBe(false);
     }
 
-    function it_can_be_final()
+    function it_can_be_final(): void
     {
         $this->isFinal->shouldBe(false);
         $this->makeFinal();
@@ -77,7 +77,7 @@ class ObjektSpec extends ObjectBehavior
         $this->isFinal->shouldBe(false);
     }
 
-    function it_can_have_a_parent(Objekt $parent)
+    function it_can_have_a_parent(Objekt $parent): void
     {
         $this->hasParent()->shouldBe(false);
         $this->parent->shouldBe(null);
@@ -91,28 +91,28 @@ class ObjektSpec extends ObjectBehavior
         $this->parent->shouldBe(null);
     }
 
-    function it_can_implement_contracts(Contract $contract)
+    function it_can_implement_contracts(Contract $contract): void
     {
         $this->contracts->shouldBe([]);
         $this->implement($contract);
         $this->contracts->shouldBe([$contract]);
     }
 
-    function it_can_have_constants(Constant $constant)
+    function it_can_have_constants(Constant $constant): void
     {
         $this->constants->shouldBe([]);
         $this->addConstant($constant);
         $this->constants->shouldBe([$constant]);
     }
 
-    function it_can_have_properties(Property $property)
+    function it_can_have_properties(Property $property): void
     {
         $this->properties->shouldBe([]);
         $this->addProperty($property);
         $this->properties->shouldBe([$property]);
     }
 
-    function it_can_have_methods(Method $method)
+    function it_can_have_methods(Method $method): void
     {
         $this->methods->shouldBe([]);
         $this->addMethod($method);

--- a/spec/Memio/Model/ObjektSpec.php
+++ b/spec/Memio/Model/ObjektSpec.php
@@ -125,5 +125,7 @@ class ObjektSpec extends ObjectBehavior
         $this->attributes->shouldBe([]);
         $this->addAttribute($attribute);
         $this->attributes->shouldBe([$attribute]);
+        $this->removeAttributes();
+        $this->attributes->shouldBe([]);
     }
 }

--- a/spec/Memio/Model/ObjektSpec.php
+++ b/spec/Memio/Model/ObjektSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Memio\Model;
 
+use Memio\Model\Attribute;
 use Memio\Model\Constant;
 use Memio\Model\Contract;
 use Memio\Model\Method;
@@ -117,5 +118,12 @@ class ObjektSpec extends ObjectBehavior
         $this->methods->shouldBe([]);
         $this->addMethod($method);
         $this->methods->shouldBe([$method]);
+    }
+
+    function it_can_have_attributes(Attribute $attribute): void
+    {
+        $this->attributes->shouldBe([]);
+        $this->addAttribute($attribute);
+        $this->attributes->shouldBe([$attribute]);
     }
 }

--- a/spec/Memio/Model/ObjektSpec.php
+++ b/spec/Memio/Model/ObjektSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/ApiTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/ApiTagSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 
 class ApiTagSpec extends ObjectBehavior
 {
-    function it_can_have_a_since_version()
+    function it_can_have_a_since_version(): void
     {
         $this->beConstructedWith('v2.1');
 

--- a/spec/Memio/Model/Phpdoc/ApiTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/ApiTagSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/DeprecationTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/DeprecationTagSpec.php
@@ -17,13 +17,13 @@ use PhpSpec\ObjectBehavior;
 
 class DeprecationTagSpec extends ObjectBehavior
 {
-    function it_can_be_just_a_tag()
+    function it_can_be_just_a_tag(): void
     {
         $this->version->shouldBe(null);
         $this->description->shouldBe(null);
     }
 
-    function it_can_have_a_version()
+    function it_can_have_a_version(): void
     {
         $this->beConstructedWith('v2.1');
 
@@ -31,7 +31,7 @@ class DeprecationTagSpec extends ObjectBehavior
         $this->description->shouldBe(null);
     }
 
-    function it_can_have_a_description()
+    function it_can_have_a_description(): void
     {
         $this->beConstructedWith('v2.1', 'Use Objekt#myMethod instead');
 

--- a/spec/Memio/Model/Phpdoc/DeprecationTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/DeprecationTagSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/DescriptionSpec.php
+++ b/spec/Memio/Model/Phpdoc/DescriptionSpec.php
@@ -19,24 +19,24 @@ class DescriptionSpec extends ObjectBehavior
 {
     const SHORT_DESCRIPTION = 'This is a short description';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::SHORT_DESCRIPTION);
     }
 
-    function it_has_a_short_description()
+    function it_has_a_short_description(): void
     {
         $this->lines->shouldBe([self::SHORT_DESCRIPTION]);
     }
 
-    function it_can_have_empty_lines()
+    function it_can_have_empty_lines(): void
     {
         $this->addEmptyLine();
 
         $this->lines->shouldBe([self::SHORT_DESCRIPTION, '']);
     }
 
-    function it_can_have_long_description()
+    function it_can_have_long_description(): void
     {
         $longDescription = [
             'Long descriptions can span on many lines',

--- a/spec/Memio/Model/Phpdoc/DescriptionSpec.php
+++ b/spec/Memio/Model/Phpdoc/DescriptionSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/DescriptionSpec.php
+++ b/spec/Memio/Model/Phpdoc/DescriptionSpec.php
@@ -50,7 +50,7 @@ class DescriptionSpec extends ObjectBehavior
 
         $this->lines->shouldBe(array_merge(
             [self::SHORT_DESCRIPTION],
-            $longDescription
+            $longDescription,
         ));
     }
 }

--- a/spec/Memio/Model/Phpdoc/LicensePhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/LicensePhpdocSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/LicensePhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/LicensePhpdocSpec.php
@@ -21,22 +21,22 @@ class LicensePhpdocSpec extends ObjectBehavior
     const AUTHOR_NAME = 'Loïc Faugeron';
     const AUTHOR_EMAIL = 'faugeron.loic@gmail.com';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::PROJECT_NAME, self::AUTHOR_NAME, self::AUTHOR_EMAIL);
     }
 
-    function it_has_project_name()
+    function it_has_project_name(): void
     {
         $this->projectName->shouldBe(self::PROJECT_NAME);
     }
 
-    function it_has_author_name()
+    function it_has_author_name(): void
     {
         $this->authorName->shouldBe(self::AUTHOR_NAME);
     }
 
-    function it_has_author_email()
+    function it_has_author_email(): void
     {
         $this->authorEmail->shouldBe(self::AUTHOR_EMAIL);
     }

--- a/spec/Memio/Model/Phpdoc/MethodPhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/MethodPhpdocSpec.php
@@ -21,33 +21,33 @@ use PhpSpec\ObjectBehavior;
 
 class MethodPhpdocSpec extends ObjectBehavior
 {
-    function it_can_be_empty()
+    function it_can_be_empty(): void
     {
         $this->isEmpty()->shouldBe(true);
     }
 
-    function it_can_have_description(Description $description)
+    function it_can_have_description(Description $description): void
     {
         $this->setDescription($description);
         $this->description->shouldBe($description);
         $this->isEmpty(false);
     }
 
-    function it_can_have_parameters(ParameterTag $parameterTag)
+    function it_can_have_parameters(ParameterTag $parameterTag): void
     {
         $this->addParameterTag($parameterTag);
         $this->parameterTags->shouldBe([$parameterTag]);
         $this->isEmpty(false);
     }
 
-    function it_can_be_tagged_as_api(ApiTag $apiTag)
+    function it_can_be_tagged_as_api(ApiTag $apiTag): void
     {
         $this->setApiTag($apiTag);
         $this->apiTag->shouldBe($apiTag);
         $this->isEmpty()->shouldBe(false);
     }
 
-    function it_can_be_tagged_as_deprecated(DeprecationTag $deprecationTag)
+    function it_can_be_tagged_as_deprecated(DeprecationTag $deprecationTag): void
     {
         $this->setDeprecationTag($deprecationTag);
         $this->deprecationTag->shouldBe($deprecationTag);

--- a/spec/Memio/Model/Phpdoc/MethodPhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/MethodPhpdocSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/ParameterTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/ParameterTagSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 
 class ParameterTagSpec extends ObjectBehavior
 {
-    function it_has_a_type_and_a_name()
+    function it_has_a_type_and_a_name(): void
     {
         $this->beConstructedWith('Vendor\Project\MyClass', 'myClass');
 
@@ -25,7 +25,7 @@ class ParameterTagSpec extends ObjectBehavior
         $this->name->shouldBe('myClass');
     }
 
-    function it_can_have_a_description()
+    function it_can_have_a_description(): void
     {
         $this->beConstructedWith('Vendor\Project\MyClass', 'myClass', 'description');
 

--- a/spec/Memio/Model/Phpdoc/ParameterTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/ParameterTagSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/PropertyPhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/PropertyPhpdocSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/PropertyPhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/PropertyPhpdocSpec.php
@@ -18,12 +18,12 @@ use PhpSpec\ObjectBehavior;
 
 class PropertyPhpdocSpec extends ObjectBehavior
 {
-    function it_can_be_empty()
+    function it_can_be_empty(): void
     {
         $this->isEmpty()->shouldBe(true);
     }
 
-    function it_can_have_a_property_tag(VariableTag $variableTag)
+    function it_can_have_a_property_tag(VariableTag $variableTag): void
     {
         $this->setVariableTag($variableTag);
         $this->variableTag->shouldBe($variableTag);

--- a/spec/Memio/Model/Phpdoc/StructurePhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/StructurePhpdocSpec.php
@@ -20,26 +20,26 @@ use PhpSpec\ObjectBehavior;
 
 class StructurePhpdocSpec extends ObjectBehavior
 {
-    function it_can_be_empty()
+    function it_can_be_empty(): void
     {
         $this->isEmpty()->shouldBe(true);
     }
 
-    function it_can_have_description(Description $description)
+    function it_can_have_description(Description $description): void
     {
         $this->setDescription($description);
         $this->description->shouldBe($description);
         $this->isEmpty(false);
     }
 
-    function it_can_be_tagged_as_api(ApiTag $apiTag)
+    function it_can_be_tagged_as_api(ApiTag $apiTag): void
     {
         $this->setApiTag($apiTag);
         $this->apiTag->shouldBe($apiTag);
         $this->isEmpty()->shouldBe(false);
     }
 
-    function it_can_be_tagged_as_deprecated(DeprecationTag $deprecationTag)
+    function it_can_be_tagged_as_deprecated(DeprecationTag $deprecationTag): void
     {
         $this->setDeprecationTag($deprecationTag);
         $this->deprecationTag->shouldBe($deprecationTag);

--- a/spec/Memio/Model/Phpdoc/StructurePhpdocSpec.php
+++ b/spec/Memio/Model/Phpdoc/StructurePhpdocSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/Phpdoc/VariableTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/VariableTagSpec.php
@@ -17,14 +17,14 @@ use PhpSpec\ObjectBehavior;
 
 class VariableTagSpec extends ObjectBehavior
 {
-    function it_has_a_type()
+    function it_has_a_type(): void
     {
         $this->beConstructedWith('string');
 
         $this->type->name->shouldBe('string');
     }
 
-    function it_can_have_a_fully_qualified_name()
+    function it_can_have_a_fully_qualified_name(): void
     {
         $this->beConstructedWith('Vendor\Project\MyClass');
 

--- a/spec/Memio/Model/Phpdoc/VariableTagSpec.php
+++ b/spec/Memio/Model/Phpdoc/VariableTagSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/PropertySpec.php
+++ b/spec/Memio/Model/PropertySpec.php
@@ -86,5 +86,7 @@ class PropertySpec extends ObjectBehavior
         $this->attributes->shouldBe([]);
         $this->addAttribute($attribute);
         $this->attributes->shouldBe([$attribute]);
+        $this->removeAttributes();
+        $this->attributes->shouldBe([]);
     }
 }

--- a/spec/Memio/Model/PropertySpec.php
+++ b/spec/Memio/Model/PropertySpec.php
@@ -20,24 +20,24 @@ class PropertySpec extends ObjectBehavior
 {
     const NAME = 'dateTime';
 
-    function let()
+    function let(): void
     {
         $this->beConstructedWith(self::NAME);
     }
 
-    function it_has_a_name()
+    function it_has_a_name(): void
     {
         $this->name->shouldBe(self::NAME);
     }
 
-    function it_can_have_phpdoc(PropertyPhpdoc $phpdoc)
+    function it_can_have_phpdoc(PropertyPhpdoc $phpdoc): void
     {
         $this->propertyPhpdoc->shouldBe(null);
         $this->setPhpdoc($phpdoc);
         $this->propertyPhpdoc->shouldBe($phpdoc);
     }
 
-    function it_has_visibility()
+    function it_has_visibility(): void
     {
         $this->visibility->shouldBe('private');
 
@@ -51,7 +51,7 @@ class PropertySpec extends ObjectBehavior
         $this->visibility->shouldBe('private');
     }
 
-    function it_can_have_staticness()
+    function it_can_have_staticness(): void
     {
         $this->isStatic->shouldBe(false);
 
@@ -62,7 +62,7 @@ class PropertySpec extends ObjectBehavior
         $this->isStatic->shouldBe(false);
     }
 
-    function it_can_have_a_default_value()
+    function it_can_have_a_default_value(): void
     {
         $this->defaultValue->shouldBe(null);
         $this->setDefaultValue('null');

--- a/spec/Memio/Model/PropertySpec.php
+++ b/spec/Memio/Model/PropertySpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Memio\Model;
 
+use Memio\Model\Attribute;
 use Memio\Model\Phpdoc\PropertyPhpdoc;
 use PhpSpec\ObjectBehavior;
 
@@ -78,5 +79,12 @@ class PropertySpec extends ObjectBehavior
         $this->defaultValue->shouldBe(null);
         $this->setDefaultValue('null');
         $this->defaultValue->shouldBe('null');
+    }
+
+    function it_can_have_attributes(Attribute $attribute): void
+    {
+        $this->attributes->shouldBe([]);
+        $this->addAttribute($attribute);
+        $this->attributes->shouldBe([$attribute]);
     }
 }

--- a/spec/Memio/Model/PropertySpec.php
+++ b/spec/Memio/Model/PropertySpec.php
@@ -62,6 +62,17 @@ class PropertySpec extends ObjectBehavior
         $this->isStatic->shouldBe(false);
     }
 
+    function it_can_have_a_type(): void
+    {
+        $this->type->shouldBe(null);
+
+        $this->setType('int');
+        $this->type->name->shouldBe('int');
+
+        $this->removeType();
+        $this->type->shouldBe(null);
+    }
+
     function it_can_have_a_default_value(): void
     {
         $this->defaultValue->shouldBe(null);

--- a/spec/Memio/Model/PropertySpec.php
+++ b/spec/Memio/Model/PropertySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/spec/Memio/Model/TypeSpec.php
+++ b/spec/Memio/Model/TypeSpec.php
@@ -205,6 +205,7 @@ class TypeSpec extends ObjectBehavior
 
         $this->getName()->shouldBe('mixed');
         $this->isObject()->shouldBe(false);
+        $this->hasTypeHint()->shouldBe(true);
     }
 
     function it_can_be_a_nullable_object(): void

--- a/spec/Memio/Model/TypeSpec.php
+++ b/spec/Memio/Model/TypeSpec.php
@@ -23,6 +23,7 @@ class TypeSpec extends ObjectBehavior
 
         $this->getName()->shouldBe('Vendor\Project\MyClass');
         $this->isObject()->shouldBe(true);
+        $this->isNullable()->shouldBe(false);
     }
 
     function it_can_have_a_type_hint_if_it_is_an_object(): void
@@ -204,5 +205,44 @@ class TypeSpec extends ObjectBehavior
 
         $this->getName()->shouldBe('mixed');
         $this->isObject()->shouldBe(false);
+    }
+
+    function it_can_be_a_nullable_object(): void
+    {
+        $this->beConstructedWith('?DateTime');
+
+        $this->getName()->shouldBe('DateTime');
+        $this->isObject()->shouldBe(true);
+        $this->hasTypeHint()->shouldBe(true);
+        $this->isNullable()->shouldBe(true);
+    }
+
+    function it_can_be_a_nullable_scalar(): void
+    {
+        $this->beConstructedWith('?string');
+
+        $this->getName()->shouldBe('string');
+        $this->isObject()->shouldBe(false);
+        $this->hasTypeHint()->shouldBe(true);
+        $this->isNullable()->shouldBe(true);
+    }
+
+    function it_can_be_a_nullable_array(): void
+    {
+        $this->beConstructedWith('?array');
+
+        $this->getName()->shouldBe('array');
+        $this->isObject()->shouldBe(false);
+        $this->hasTypeHint()->shouldBe(true);
+        $this->isNullable()->shouldBe(true);
+    }
+
+    function it_normalizes_nullable_names(): void
+    {
+        $this->beConstructedWith('?boolean');
+
+        $this->getName()->shouldBe('bool');
+        $this->isObject()->shouldBe(false);
+        $this->isNullable()->shouldBe(true);
     }
 }

--- a/spec/Memio/Model/TypeSpec.php
+++ b/spec/Memio/Model/TypeSpec.php
@@ -75,34 +75,6 @@ class TypeSpec extends ObjectBehavior
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_string_from_php_7_0(): void
-    {
-        $this->beConstructedWith('string');
-
-        $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
-    }
-
-    function it_can_have_a_type_hint_if_it_is_an_integer_from_php_7_0(): void
-    {
-        $this->beConstructedWith('int');
-
-        $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
-    }
-
-    function it_can_have_a_type_hint_if_it_is_a_float_from_php_7_0(): void
-    {
-        $this->beConstructedWith('float');
-
-        $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
-    }
-
-    function it_can_have_a_type_hint_if_it_is_a_boolean_from_php_7_0(): void
-    {
-        $this->beConstructedWith('bool');
-
-        $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
-    }
-
     function it_can_be_an_array(): void
     {
         $this->beConstructedWith('array');

--- a/spec/Memio/Model/TypeSpec.php
+++ b/spec/Memio/Model/TypeSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 
 class TypeSpec extends ObjectBehavior
 {
-    function it_can_be_an_object()
+    function it_can_be_an_object(): void
     {
         $this->beConstructedWith('Vendor\Project\MyClass');
 
@@ -25,84 +25,84 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_an_object()
+    function it_can_have_a_type_hint_if_it_is_an_object(): void
     {
         $this->beConstructedWith('DateTime');
 
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_an_array()
+    function it_can_have_a_type_hint_if_it_is_an_array(): void
     {
         $this->beConstructedWith('array');
 
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_callable()
+    function it_can_have_a_type_hint_if_it_is_a_callable(): void
     {
         $this->beConstructedWith('callable');
 
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_string()
+    function it_can_have_a_type_hint_if_it_is_a_string(): void
     {
         $this->beConstructedWith('string');
 
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_an_integer()
+    function it_can_have_a_type_hint_if_it_is_an_integer(): void
     {
         $this->beConstructedWith('int');
 
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_float()
+    function it_can_have_a_type_hint_if_it_is_a_float(): void
     {
         $this->beconstructedwith('float');
 
         $this->hastypehint()->shouldbe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_boolean()
+    function it_can_have_a_type_hint_if_it_is_a_boolean(): void
     {
         $this->beConstructedWith('bool');
 
         $this->hasTypeHint()->shouldBe(true);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_string_from_php_7_0()
+    function it_can_have_a_type_hint_if_it_is_a_string_from_php_7_0(): void
     {
         $this->beConstructedWith('string');
 
         $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
     }
 
-    function it_can_have_a_type_hint_if_it_is_an_integer_from_php_7_0()
+    function it_can_have_a_type_hint_if_it_is_an_integer_from_php_7_0(): void
     {
         $this->beConstructedWith('int');
 
         $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_float_from_php_7_0()
+    function it_can_have_a_type_hint_if_it_is_a_float_from_php_7_0(): void
     {
         $this->beConstructedWith('float');
 
         $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
     }
 
-    function it_can_have_a_type_hint_if_it_is_a_boolean_from_php_7_0()
+    function it_can_have_a_type_hint_if_it_is_a_boolean_from_php_7_0(): void
     {
         $this->beConstructedWith('bool');
 
         $this->hasTypeHint()->shouldBe(version_compare(PHP_VERSION, '7.0.0') >= 0);
     }
 
-    function it_can_be_an_array()
+    function it_can_be_an_array(): void
     {
         $this->beConstructedWith('array');
 
@@ -110,7 +110,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_a_callable()
+    function it_can_be_a_callable(): void
     {
         $this->beConstructedWith('callable');
 
@@ -118,7 +118,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_a_string()
+    function it_can_be_a_string(): void
     {
         $this->beConstructedWith('string');
 
@@ -126,7 +126,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_a_boolean()
+    function it_can_be_a_boolean(): void
     {
         $this->beConstructedWith('bool');
 
@@ -134,7 +134,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_normalizes_boolean_name()
+    function it_normalizes_boolean_name(): void
     {
         $this->beConstructedWith('boolean');
 
@@ -142,7 +142,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_a_resource()
+    function it_can_be_a_resource(): void
     {
         $this->beConstructedWith('resource');
 
@@ -150,7 +150,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_an_integer()
+    function it_can_be_an_integer(): void
     {
         $this->beConstructedWith('int');
 
@@ -158,7 +158,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_normalizes_integer_name()
+    function it_normalizes_integer_name(): void
     {
         $this->beConstructedWith('integer');
 
@@ -166,7 +166,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_a_float()
+    function it_can_be_a_float(): void
     {
         $this->beConstructedWith('float');
 
@@ -174,7 +174,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_normalizes_float_name()
+    function it_normalizes_float_name(): void
     {
         $this->beConstructedWith('double');
 
@@ -182,7 +182,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_null()
+    function it_can_be_null(): void
     {
         $this->beConstructedWith('null');
 
@@ -190,7 +190,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_normalizes_null_name()
+    function it_normalizes_null_name(): void
     {
         $this->beConstructedWith('NULL');
 
@@ -198,7 +198,7 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
     }
 
-    function it_can_be_unknown()
+    function it_can_be_unknown(): void
     {
         $this->beConstructedWith('mixed');
 

--- a/spec/Memio/Model/TypeSpec.php
+++ b/spec/Memio/Model/TypeSpec.php
@@ -245,4 +245,40 @@ class TypeSpec extends ObjectBehavior
         $this->isObject()->shouldBe(false);
         $this->isNullable()->shouldBe(true);
     }
+
+    function it_can_be_a_union_type(): void
+    {
+        $this->beConstructedWith('string|int');
+
+        $this->getName()->shouldBe('string|int');
+        $this->isUnionType->shouldBe(true);
+        $this->hasTypeHint()->shouldBe(true);
+        $this->types->shouldHaveCount(2);
+    }
+
+    function it_can_be_a_nullable_union_type(): void
+    {
+        $this->beConstructedWith('string|null');
+
+        $this->getName()->shouldBe('string|null');
+        $this->isUnionType->shouldBe(true);
+        $this->isNullable()->shouldBe(true);
+    }
+
+    function it_normalizes_union_type_names(): void
+    {
+        $this->beConstructedWith('boolean|integer');
+
+        $this->getName()->shouldBe('bool|int');
+        $this->isUnionType->shouldBe(true);
+    }
+
+    function it_can_be_a_union_type_with_object(): void
+    {
+        $this->beConstructedWith('DateTime|string');
+
+        $this->getName()->shouldBe('DateTime|string');
+        $this->isUnionType->shouldBe(true);
+        $this->types[0]->isObject->shouldBe(true);
+    }
 }

--- a/spec/Memio/Model/TypeSpec.php
+++ b/spec/Memio/Model/TypeSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -19,6 +19,7 @@ namespace Memio\Model;
 class Argument
 {
     public array $attributes = [];
+    public string $visibility = '';
     public Type $type;
     public ?string $defaultValue = null;
     public bool $isVariadic = false;
@@ -93,6 +94,46 @@ class Argument
     public function removeVariadic(): self
     {
         $this->isVariadic = false;
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function makePublic(): self
+    {
+        $this->visibility = 'public';
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function makeProtected(): self
+    {
+        $this->visibility = 'protected';
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function makePrivate(): self
+    {
+        $this->visibility = 'private';
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function removeVisibility(): self
+    {
+        $this->visibility = '';
 
         return $this;
     }

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -44,6 +44,14 @@ class Argument
     /**
      * @api
      */
+    public function removeAttributes(): void
+    {
+        $this->attributes = [];
+    }
+
+    /**
+     * @api
+     */
     public function setDefaultValue(string $value): self
     {
         $this->defaultValue = $value;

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -19,17 +19,15 @@ namespace Memio\Model;
 class Argument
 {
     public Type $type;
-    public string $name;
     public ?string $defaultValue = null;
     public bool $isVariadic = false;
 
     /**
      * @api
      */
-    public function __construct(string $type, string $name)
+    public function __construct(string $type, public string $name)
     {
         $this->type = new Type($type);
-        $this->name = $name;
     }
 
     /**

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -18,6 +18,7 @@ namespace Memio\Model;
  */
 class Argument
 {
+    public array $attributes = [];
     public Type $type;
     public ?string $defaultValue = null;
     public bool $isVariadic = false;
@@ -28,6 +29,16 @@ class Argument
     public function __construct(string $type, public string $name)
     {
         $this->type = new Type($type);
+    }
+
+    /**
+     * @api
+     */
+    public function addAttribute(Attribute $attribute): self
+    {
+        $this->attributes[] = $attribute;
+
+        return $this;
     }
 
     /**

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -18,10 +18,10 @@ namespace Memio\Model;
  */
 class Argument
 {
-    public $type;
-    public $name;
-    public $defaultValue;
-    public $isVariadic = false;
+    public Type $type;
+    public string $name;
+    public ?string $defaultValue = null;
+    public bool $isVariadic = false;
 
     /**
      * @api

--- a/src/Memio/Model/Argument.php
+++ b/src/Memio/Model/Argument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Attribute.php
+++ b/src/Memio/Model/Attribute.php
@@ -16,25 +16,24 @@ namespace Memio\Model;
 /**
  * @api
  */
-class Constant
+class Attribute
 {
-    public array $attributes = [];
+    public ?string $arguments = null;
 
     /**
      * @api
      */
     public function __construct(
         public string $name,
-        public string $value,
     ) {
     }
 
     /**
      * @api
      */
-    public function addAttribute(Attribute $attribute): self
+    public function setArguments(string $arguments): self
     {
-        $this->attributes[] = $attribute;
+        $this->arguments = $arguments;
 
         return $this;
     }

--- a/src/Memio/Model/Constant.php
+++ b/src/Memio/Model/Constant.php
@@ -18,8 +18,8 @@ namespace Memio\Model;
  */
 class Constant
 {
-    public $name;
-    public $value;
+    public string $name;
+    public string $value;
 
     /**
      * @api

--- a/src/Memio/Model/Constant.php
+++ b/src/Memio/Model/Constant.php
@@ -18,15 +18,12 @@ namespace Memio\Model;
  */
 class Constant
 {
-    public string $name;
-    public string $value;
-
     /**
      * @api
      */
-    public function __construct(string $name, string $value)
-    {
-        $this->name = $name;
-        $this->value = $value;
+    public function __construct(
+        public string $name,
+        public string $value,
+    ) {
     }
 }

--- a/src/Memio/Model/Constant.php
+++ b/src/Memio/Model/Constant.php
@@ -38,4 +38,12 @@ class Constant
 
         return $this;
     }
+
+    /**
+     * @api
+     */
+    public function removeAttributes(): void
+    {
+        $this->attributes = [];
+    }
 }

--- a/src/Memio/Model/Constant.php
+++ b/src/Memio/Model/Constant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Contract.php
+++ b/src/Memio/Model/Contract.php
@@ -75,6 +75,14 @@ class Contract implements Structure
     /**
      * @api
      */
+    public function removeAttributes(): void
+    {
+        $this->attributes = [];
+    }
+
+    /**
+     * @api
+     */
     public function extend(Contract $contract): self
     {
         $this->contracts[] = $contract;

--- a/src/Memio/Model/Contract.php
+++ b/src/Memio/Model/Contract.php
@@ -22,11 +22,11 @@ use Memio\Model\Phpdoc\StructurePhpdoc;
  */
 class Contract implements Structure
 {
-    public $fullyQualifiedName;
-    public $structurePhpdoc;
-    public $contracts = [];
-    public $constants = [];
-    public $methods = [];
+    public FullyQualifiedName $fullyQualifiedName;
+    public ?StructurePhpdoc $structurePhpdoc = null;
+    public array $contracts = [];
+    public array $constants = [];
+    public array $methods = [];
 
     /**
      * @api

--- a/src/Memio/Model/Contract.php
+++ b/src/Memio/Model/Contract.php
@@ -24,6 +24,7 @@ class Contract implements Structure
 {
     public FullyQualifiedName $fullyQualifiedName;
     public ?StructurePhpdoc $structurePhpdoc = null;
+    public array $attributes = [];
     public array $contracts = [];
     public array $constants = [];
     public array $methods = [];
@@ -57,6 +58,16 @@ class Contract implements Structure
     public function setPhpdoc(StructurePhpdoc $structurePhpdoc): self
     {
         $this->structurePhpdoc = $structurePhpdoc;
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function addAttribute(Attribute $attribute): self
+    {
+        $this->attributes[] = $attribute;
 
         return $this;
     }

--- a/src/Memio/Model/Contract.php
+++ b/src/Memio/Model/Contract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/File.php
+++ b/src/Memio/Model/File.php
@@ -20,7 +20,6 @@ use Memio\Model\Phpdoc\LicensePhpdoc;
  */
 class File
 {
-    public string $filename;
     public ?LicensePhpdoc $licensePhpdoc = null;
     public array $fullyQualifiedNames = [];
     public ?Structure $structure = null;
@@ -28,9 +27,8 @@ class File
     /**
      * @api
      */
-    public function __construct(string $filename)
+    public function __construct(public string $filename)
     {
-        $this->filename = $filename;
     }
 
     /**

--- a/src/Memio/Model/File.php
+++ b/src/Memio/Model/File.php
@@ -20,10 +20,10 @@ use Memio\Model\Phpdoc\LicensePhpdoc;
  */
 class File
 {
-    public $filename;
-    public $licensePhpdoc;
-    public $fullyQualifiedNames = [];
-    public $structure;
+    public string $filename;
+    public ?LicensePhpdoc $licensePhpdoc = null;
+    public array $fullyQualifiedNames = [];
+    public ?Structure $structure = null;
 
     /**
      * @api

--- a/src/Memio/Model/File.php
+++ b/src/Memio/Model/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/FullyQualifiedName.php
+++ b/src/Memio/Model/FullyQualifiedName.php
@@ -21,10 +21,10 @@ class FullyQualifiedName
     public const NORMALIZATIONS = [
         'float' => 'double',
     ];
-    public $fullyQualifiedName;
-    public $name;
-    public $namespace;
-    public $alias;
+    public string $fullyQualifiedName;
+    public string $name;
+    public string $namespace;
+    public ?string $alias = null;
 
     /**
      * @api

--- a/src/Memio/Model/FullyQualifiedName.php
+++ b/src/Memio/Model/FullyQualifiedName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Method.php
+++ b/src/Memio/Model/Method.php
@@ -20,6 +20,7 @@ use Memio\Model\Phpdoc\MethodPhpdoc;
  */
 class Method
 {
+    public array $attributes = [];
     public ?MethodPhpdoc $methodPhpdoc = null;
     public bool $isAbstract = false;
     public bool $isFinal = false;
@@ -34,6 +35,16 @@ class Method
      */
     public function __construct(public string $name)
     {
+    }
+
+    /**
+     * @api
+     */
+    public function addAttribute(Attribute $attribute): self
+    {
+        $this->attributes[] = $attribute;
+
+        return $this;
     }
 
     /**

--- a/src/Memio/Model/Method.php
+++ b/src/Memio/Model/Method.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Method.php
+++ b/src/Memio/Model/Method.php
@@ -20,7 +20,6 @@ use Memio\Model\Phpdoc\MethodPhpdoc;
  */
 class Method
 {
-    public string $name;
     public ?MethodPhpdoc $methodPhpdoc = null;
     public bool $isAbstract = false;
     public bool $isFinal = false;
@@ -33,9 +32,8 @@ class Method
     /**
      * @api
      */
-    public function __construct(string $name)
+    public function __construct(public string $name)
     {
-        $this->name = $name;
     }
 
     /**

--- a/src/Memio/Model/Method.php
+++ b/src/Memio/Model/Method.php
@@ -50,6 +50,14 @@ class Method
     /**
      * @api
      */
+    public function removeAttributes(): void
+    {
+        $this->attributes = [];
+    }
+
+    /**
+     * @api
+     */
     public function setPhpdoc(MethodPhpdoc $methodPhpdoc): self
     {
         $this->methodPhpdoc = $methodPhpdoc;

--- a/src/Memio/Model/Method.php
+++ b/src/Memio/Model/Method.php
@@ -20,15 +20,15 @@ use Memio\Model\Phpdoc\MethodPhpdoc;
  */
 class Method
 {
-    public $name;
-    public $methodPhpdoc;
-    public $isAbstract = false;
-    public $isFinal = false;
-    public $visibility = 'public';
-    public $isStatic = false;
-    public $arguments = [];
-    public $body = '';
-    public $returnType;
+    public string $name;
+    public ?MethodPhpdoc $methodPhpdoc = null;
+    public bool $isAbstract = false;
+    public bool $isFinal = false;
+    public string $visibility = 'public';
+    public bool $isStatic = false;
+    public array $arguments = [];
+    public string $body = '';
+    public ?string $returnType = null;
 
     /**
      * @api

--- a/src/Memio/Model/Objekt.php
+++ b/src/Memio/Model/Objekt.php
@@ -28,6 +28,7 @@ class Objekt implements Structure
     public bool $isFinal = false;
     public ?Objekt $parent = null;
     public array $contracts = [];
+    public array $attributes = [];
     public array $constants = [];
     public array $properties = [];
     public array $methods = [];
@@ -126,6 +127,16 @@ class Objekt implements Structure
     public function removeParent(): self
     {
         $this->parent = null;
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function addAttribute(Attribute $attribute): self
+    {
+        $this->attributes[] = $attribute;
 
         return $this;
     }

--- a/src/Memio/Model/Objekt.php
+++ b/src/Memio/Model/Objekt.php
@@ -144,6 +144,14 @@ class Objekt implements Structure
     /**
      * @api
      */
+    public function removeAttributes(): void
+    {
+        $this->attributes = [];
+    }
+
+    /**
+     * @api
+     */
     public function implement(Contract $contract): self
     {
         $this->contracts[] = $contract;

--- a/src/Memio/Model/Objekt.php
+++ b/src/Memio/Model/Objekt.php
@@ -22,15 +22,15 @@ use Memio\Model\Phpdoc\StructurePhpdoc;
  */
 class Objekt implements Structure
 {
-    public $fullyQualifiedName;
-    public $structurePhpdoc;
-    public $isAbstract = false;
-    public $isFinal = false;
-    public $parent;
-    public $contracts = [];
-    public $constants = [];
-    public $properties = [];
-    public $methods = [];
+    public FullyQualifiedName $fullyQualifiedName;
+    public ?StructurePhpdoc $structurePhpdoc = null;
+    public bool $isAbstract = false;
+    public bool $isFinal = false;
+    public ?Objekt $parent = null;
+    public array $contracts = [];
+    public array $constants = [];
+    public array $properties = [];
+    public array $methods = [];
 
     /**
      * @api

--- a/src/Memio/Model/Objekt.php
+++ b/src/Memio/Model/Objekt.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/ApiTag.php
+++ b/src/Memio/Model/Phpdoc/ApiTag.php
@@ -18,13 +18,10 @@ namespace Memio\Model\Phpdoc;
  */
 class ApiTag
 {
-    public ?string $since;
-
     /**
      * @api
      */
-    public function __construct(?string $since = null)
+    public function __construct(public ?string $since = null)
     {
-        $this->since = $since;
     }
 }

--- a/src/Memio/Model/Phpdoc/ApiTag.php
+++ b/src/Memio/Model/Phpdoc/ApiTag.php
@@ -18,7 +18,7 @@ namespace Memio\Model\Phpdoc;
  */
 class ApiTag
 {
-    public $since;
+    public ?string $since;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/ApiTag.php
+++ b/src/Memio/Model/Phpdoc/ApiTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/DeprecationTag.php
+++ b/src/Memio/Model/Phpdoc/DeprecationTag.php
@@ -18,8 +18,8 @@ namespace Memio\Model\Phpdoc;
  */
 class DeprecationTag
 {
-    public $version;
-    public $description;
+    public ?string $version;
+    public ?string $description;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/DeprecationTag.php
+++ b/src/Memio/Model/Phpdoc/DeprecationTag.php
@@ -18,17 +18,12 @@ namespace Memio\Model\Phpdoc;
  */
 class DeprecationTag
 {
-    public ?string $version;
-    public ?string $description;
-
     /**
      * @api
      */
     public function __construct(
-        ?string $version = null,
-        ?string $description = null
+        public ?string $version = null,
+        public ?string $description = null,
     ) {
-        $this->version = $version;
-        $this->description = $description;
     }
 }

--- a/src/Memio/Model/Phpdoc/DeprecationTag.php
+++ b/src/Memio/Model/Phpdoc/DeprecationTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/Description.php
+++ b/src/Memio/Model/Phpdoc/Description.php
@@ -15,7 +15,7 @@ namespace Memio\Model\Phpdoc;
 
 class Description
 {
-    public $lines = [];
+    public array $lines = [];
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/Description.php
+++ b/src/Memio/Model/Phpdoc/Description.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/LicensePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/LicensePhpdoc.php
@@ -18,9 +18,9 @@ namespace Memio\Model\Phpdoc;
  */
 class LicensePhpdoc
 {
-    public $projectName;
-    public $authorName;
-    public $authorEmail;
+    public string $projectName;
+    public string $authorName;
+    public string $authorEmail;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/LicensePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/LicensePhpdoc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/LicensePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/LicensePhpdoc.php
@@ -18,20 +18,13 @@ namespace Memio\Model\Phpdoc;
  */
 class LicensePhpdoc
 {
-    public string $projectName;
-    public string $authorName;
-    public string $authorEmail;
-
     /**
      * @api
      */
     public function __construct(
-        string $projectName,
-        string $authorName,
-        string $authorEmail
+        public string $projectName,
+        public string $authorName,
+        public string $authorEmail,
     ) {
-        $this->projectName = $projectName;
-        $this->authorName = $authorName;
-        $this->authorEmail = $authorEmail;
     }
 }

--- a/src/Memio/Model/Phpdoc/MethodPhpdoc.php
+++ b/src/Memio/Model/Phpdoc/MethodPhpdoc.php
@@ -18,12 +18,12 @@ namespace Memio\Model\Phpdoc;
  */
 class MethodPhpdoc
 {
-    public $apiTag;
-    public $deprecationTag;
-    public $returnTag;
-    public $description;
-    public $parameterTags = [];
-    public $throwTags = [];
+    public ?ApiTag $apiTag = null;
+    public ?DeprecationTag $deprecationTag = null;
+    public ?ReturnTag $returnTag = null;
+    public ?Description $description = null;
+    public array $parameterTags = [];
+    public array $throwTags = [];
 
     /**
      * @api
@@ -48,7 +48,7 @@ class MethodPhpdoc
     /**
      * @api
      */
-    public function setDescription($description): self
+    public function setDescription(Description $description): self
     {
         $this->description = $description;
 

--- a/src/Memio/Model/Phpdoc/MethodPhpdoc.php
+++ b/src/Memio/Model/Phpdoc/MethodPhpdoc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/ParameterTag.php
+++ b/src/Memio/Model/Phpdoc/ParameterTag.php
@@ -21,19 +21,15 @@ use Memio\Model\Type;
 class ParameterTag
 {
     public Type $type;
-    public string $name;
-    public ?string $description;
 
     /**
      * @api
      */
     public function __construct(
         string $type,
-        string $name,
-        ?string $description = null
+        public string $name,
+        public ?string $description = null,
     ) {
         $this->type = new Type($type);
-        $this->name = $name;
-        $this->description = $description;
     }
 }

--- a/src/Memio/Model/Phpdoc/ParameterTag.php
+++ b/src/Memio/Model/Phpdoc/ParameterTag.php
@@ -20,9 +20,9 @@ use Memio\Model\Type;
  */
 class ParameterTag
 {
-    public $type;
-    public $name;
-    public $description;
+    public Type $type;
+    public string $name;
+    public ?string $description;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/ParameterTag.php
+++ b/src/Memio/Model/Phpdoc/ParameterTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/PropertyPhpdoc.php
+++ b/src/Memio/Model/Phpdoc/PropertyPhpdoc.php
@@ -18,7 +18,7 @@ namespace Memio\Model\Phpdoc;
  */
 class PropertyPhpdoc
 {
-    public $variableTag;
+    public ?VariableTag $variableTag = null;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/PropertyPhpdoc.php
+++ b/src/Memio/Model/Phpdoc/PropertyPhpdoc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/ReturnTag.php
+++ b/src/Memio/Model/Phpdoc/ReturnTag.php
@@ -15,7 +15,7 @@ namespace Memio\Model\Phpdoc;
 
 class ReturnTag
 {
-    public $type;
+    public string $type;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/ReturnTag.php
+++ b/src/Memio/Model/Phpdoc/ReturnTag.php
@@ -15,13 +15,10 @@ namespace Memio\Model\Phpdoc;
 
 class ReturnTag
 {
-    public string $type;
-
     /**
      * @api
      */
-    public function __construct(string $type)
+    public function __construct(public string $type)
     {
-        $this->type = $type;
     }
 }

--- a/src/Memio/Model/Phpdoc/ReturnTag.php
+++ b/src/Memio/Model/Phpdoc/ReturnTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/StructurePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/StructurePhpdoc.php
@@ -18,9 +18,9 @@ namespace Memio\Model\Phpdoc;
  */
 class StructurePhpdoc
 {
-    public $apiTag;
-    public $deprecationTag;
-    public $description;
+    public ?ApiTag $apiTag = null;
+    public ?DeprecationTag $deprecationTag = null;
+    public ?Description $description = null;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/StructurePhpdoc.php
+++ b/src/Memio/Model/Phpdoc/StructurePhpdoc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/ThrowTag.php
+++ b/src/Memio/Model/Phpdoc/ThrowTag.php
@@ -15,13 +15,10 @@ namespace Memio\Model\Phpdoc;
 
 class ThrowTag
 {
-    public string $exception;
-
     /**
      * @api
      */
-    public function __construct(string $exception)
+    public function __construct(public string $exception)
     {
-        $this->exception = $exception;
     }
 }

--- a/src/Memio/Model/Phpdoc/ThrowTag.php
+++ b/src/Memio/Model/Phpdoc/ThrowTag.php
@@ -15,7 +15,7 @@ namespace Memio\Model\Phpdoc;
 
 class ThrowTag
 {
-    public $exception;
+    public string $exception;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/ThrowTag.php
+++ b/src/Memio/Model/Phpdoc/ThrowTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Phpdoc/VariableTag.php
+++ b/src/Memio/Model/Phpdoc/VariableTag.php
@@ -17,7 +17,7 @@ use Memio\Model\Type;
 
 class VariableTag
 {
-    public $type;
+    public Type $type;
 
     /**
      * @api

--- a/src/Memio/Model/Phpdoc/VariableTag.php
+++ b/src/Memio/Model/Phpdoc/VariableTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -57,7 +57,7 @@ class Property
     /**
      * @api
      */
-    public function removeStatic()
+    public function removeStatic(): void
     {
         $this->isStatic = false;
     }

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -20,12 +20,12 @@ use Memio\Model\Phpdoc\PropertyPhpdoc;
  */
 class Property
 {
-    public $name;
-    public $type;
-    public $propertyPhpdoc;
-    public $isStatic = false;
-    public $visibility = 'private';
-    public $defaultValue;
+    public string $name;
+    public ?Type $type = null;
+    public ?PropertyPhpdoc $propertyPhpdoc = null;
+    public bool $isStatic = false;
+    public string $visibility = 'private';
+    public ?string $defaultValue = null;
 
     /**
      * @api

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -20,6 +20,7 @@ use Memio\Model\Phpdoc\PropertyPhpdoc;
  */
 class Property
 {
+    public array $attributes = [];
     public ?Type $type = null;
     public ?PropertyPhpdoc $propertyPhpdoc = null;
     public bool $isStatic = false;
@@ -31,6 +32,16 @@ class Property
      */
     public function __construct(public string $name)
     {
+    }
+
+    /**
+     * @api
+     */
+    public function addAttribute(Attribute $attribute): self
+    {
+        $this->attributes[] = $attribute;
+
+        return $this;
     }
 
     /**

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -21,6 +21,7 @@ use Memio\Model\Phpdoc\PropertyPhpdoc;
 class Property
 {
     public $name;
+    public $type;
     public $propertyPhpdoc;
     public $isStatic = false;
     public $visibility = 'private';
@@ -90,6 +91,24 @@ class Property
         $this->visibility = 'public';
 
         return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function setType(string $type): self
+    {
+        $this->type = new Type($type);
+
+        return $this;
+    }
+
+    /**
+     * @api
+     */
+    public function removeType(): void
+    {
+        $this->type = null;
     }
 
     /**

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -47,6 +47,14 @@ class Property
     /**
      * @api
      */
+    public function removeAttributes(): void
+    {
+        $this->attributes = [];
+    }
+
+    /**
+     * @api
+     */
     public function setPhpdoc(PropertyPhpdoc $propertyPhpdoc): self
     {
         $this->propertyPhpdoc = $propertyPhpdoc;

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Property.php
+++ b/src/Memio/Model/Property.php
@@ -20,7 +20,6 @@ use Memio\Model\Phpdoc\PropertyPhpdoc;
  */
 class Property
 {
-    public string $name;
     public ?Type $type = null;
     public ?PropertyPhpdoc $propertyPhpdoc = null;
     public bool $isStatic = false;
@@ -30,9 +29,8 @@ class Property
     /**
      * @api
      */
-    public function __construct(string $name)
+    public function __construct(public string $name)
     {
-        $this->name = $name;
     }
 
     /**

--- a/src/Memio/Model/Structure.php
+++ b/src/Memio/Model/Structure.php
@@ -32,4 +32,14 @@ interface Structure
      * @api
      */
     public function setPhpdoc(StructurePhpdoc $structurePhpdoc);
+
+    /**
+     * @api
+     */
+    public function addAttribute(Attribute $attribute);
+
+    /**
+     * @api
+     */
+    public function removeAttributes(): void;
 }

--- a/src/Memio/Model/Structure.php
+++ b/src/Memio/Model/Structure.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -44,9 +44,9 @@ class Type
         'string',
     ];
 
-    public $name;
-    public $isObject;
-    public $hasTypeHint;
+    public string $name;
+    public bool $isObject;
+    public bool $hasTypeHint;
 
     /**
      * @api

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -48,6 +48,9 @@ class Type
     public bool $isObject;
     public bool $hasTypeHint;
     public bool $isNullable;
+    public bool $isUnionType = false;
+    /** @var Type[] */
+    public array $types = [];
 
     /**
      * @api
@@ -57,6 +60,24 @@ class Type
         $this->isNullable = str_starts_with($name, '?');
         if ($this->isNullable) {
             $name = substr($name, 1);
+        }
+        if (str_contains($name, '|')) {
+            $this->isUnionType = true;
+            $this->hasTypeHint = true;
+            $this->isObject = false;
+            $parts = explode('|', $name);
+            $normalizedParts = [];
+            foreach ($parts as $part) {
+                $type = new self($part);
+                $this->types[] = $type;
+                $normalizedParts[] = $type->name;
+                if ('null' === $type->name) {
+                    $this->isNullable = true;
+                }
+            }
+            $this->name = implode('|', $normalizedParts);
+
+            return;
         }
         if (isset(self::NORMALIZATIONS[$name])) {
             $name = self::NORMALIZATIONS[$name];

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -35,7 +35,7 @@ class Type
         'null',
         'mixed',
     ];
-    const HAS_TYPE_HINT = [
+    public const HAS_TYPE_HINT = [
         'array',
         'callable',
         'bool',

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -42,6 +42,7 @@ class Type
         'float',
         'int',
         'string',
+        'mixed',
     ];
 
     public string $name;

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the memio/model package.
  *

--- a/src/Memio/Model/Type.php
+++ b/src/Memio/Model/Type.php
@@ -47,12 +47,17 @@ class Type
     public string $name;
     public bool $isObject;
     public bool $hasTypeHint;
+    public bool $isNullable;
 
     /**
      * @api
      */
     public function __construct(string $name)
     {
+        $this->isNullable = str_starts_with($name, '?');
+        if ($this->isNullable) {
+            $name = substr($name, 1);
+        }
         if (isset(self::NORMALIZATIONS[$name])) {
             $name = self::NORMALIZATIONS[$name];
         }
@@ -86,5 +91,13 @@ class Type
     public function hasTypeHint(): bool
     {
         return $this->hasTypeHint;
+    }
+
+    /**
+     * @api
+     */
+    public function isNullable(): bool
+    {
+        return $this->isNullable;
     }
 }


### PR DESCRIPTION
Dropped support for PHP <8.0

New features:

* added Attribute model (PHP 8.0 attributes)
* added attributes support to Objekt, Contract, Method, Property, Argument and Constant
* added union type support in Type (e.g. string|int, DateTime|null)
* added mixed type hint support in Type
* added support for class property types
* added constructor property promotion support (visibility on Argument)
* added support for nullable typehints

> AI disclosure: used Claude Code (v2.1.39, Opus 4.6), to help with the chores and the code review.